### PR TITLE
Dependency update for use SoapUI versión 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <mavenMinimumSupportedVersion>2.2.1</mavenMinimumSupportedVersion>
     <invokerParallelThreads>1</invokerParallelThreads>
     <!-- use a camel case property name otherwise, the maven invoker plugin won't use it while filtering -->
-    <soapuiVersionCurrent>4.6.4</soapuiVersionCurrent>
+    <soapuiVersionCurrent>5.1.2</soapuiVersionCurrent>
     <!-- TODO fix for http://jira.codehaus.org/browse/MINVOKER-137 -->
     <invokerProfile>defaultInvokerProfile</invokerProfile>
   </properties>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
-      <version>1.5.0</version>
+      <version>1.17.0</version>
       <scope>test</scope>
     </dependency>
     <!-- fix for #85 / TODO remove when upgrading to 5.0.0 / Also restore enforcer plugin bannedDependencies configuration -->
@@ -158,7 +158,12 @@
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-util</artifactId>
       <version>1.13.1</version>
-    </dependency>    
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.10</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/ktc/soapui/maven/extension/MultiMojoFailureException.java
+++ b/src/main/java/org/ktc/soapui/maven/extension/MultiMojoFailureException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Jesús Muñoz (LEDAmc)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.ktc.soapui.maven.extension;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoFailureException;
+
+public class MultiMojoFailureException extends MojoFailureException {
+
+	private static final long serialVersionUID = 7541580237032576130L;
+
+	public MultiMojoFailureException(List<File> failedProjects) {
+		super(String.format("Folowing projects has some failure. Please check reports: \n %s", getProjectNames(failedProjects)));
+	}
+	
+	private static String getProjectNames(List<File> failedProjects){
+		String rtn = "";
+		for (File file : failedProjects) {
+			rtn += String.format("\t%s\n", file.getPath());
+		}
+		return rtn;
+	}
+}

--- a/src/main/java/org/ktc/soapui/maven/extension/impl/runner/MockAsWarExtension.java
+++ b/src/main/java/org/ktc/soapui/maven/extension/impl/runner/MockAsWarExtension.java
@@ -17,8 +17,14 @@
 
 package org.ktc.soapui.maven.extension.impl.runner;
 
+import java.io.IOException;
+
+import org.apache.xmlbeans.XmlException;
+
+import com.eviware.soapui.impl.wsdl.WsdlProject;
 import com.eviware.soapui.mockaswar.MockAsWarProServlet;
 import com.eviware.soapui.mockaswar.MockAsWarServlet;
+import com.eviware.soapui.support.SoapUIException;
 import com.eviware.soapui.tools.MockAsWar;
 
 public class MockAsWarExtension extends MockAsWar {
@@ -27,8 +33,8 @@ public class MockAsWarExtension extends MockAsWar {
     private static String SMARTBEAR_PRO_SERVLET_CLASS_NAME = MockAsWarProServlet.class.getName();
 
     public MockAsWarExtension(String projectPath, String settingsPath, String warDir, String warFile,
-            boolean includeExt, boolean actions, boolean listeners, String localEndpoint, boolean enableWebUI) {
-        super(projectPath, settingsPath, warDir, warFile, includeExt, actions, listeners, localEndpoint, enableWebUI);
+            boolean includeExt, boolean actions, boolean listeners, String localEndpoint, boolean enableWebUI) throws XmlException, IOException, SoapUIException {
+    	super(projectPath, settingsPath, warDir, warFile, includeExt, actions, listeners, localEndpoint, enableWebUI, new WsdlProject(projectPath));
     }
 
     @Override

--- a/src/main/resources/META-INF/maven/plugin.xml
+++ b/src/main/resources/META-INF/maven/plugin.xml
@@ -602,6 +602,15 @@ either &apos;Text&apos; or &apos;Digest&apos;</description>
           of the configured outputFolder.</description>
         </parameter>
         <!-- ######## END OF SPECIFIC test-multi, added for #104 -->
+        <!-- ######## SPECIFIC failBuildIfSomeTestFail, added by Jesús Muñoz (jmunoz@leda-mc.com) -->
+        <parameter>
+          <name>failBuildIfSomeTestFail</name>
+          <type>java.lang.Boolean</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>If true, all projects will be executed and if parameter testFailIgnore is false the build will fail.</description>
+        </parameter>
+        <!-- ######## END OF SPECIFIC failBuildIfSomeTestFail, added by Jesús Muñoz (jmunoz@leda-mc.com) -->
         <!-- ######## CUSTOMIZED, added for #3 -->
         <parameter>
           <name>project</name>


### PR DESCRIPTION
I have updated dependencies for use SoapUI version 5.1.2. Into MockAsWarExtension I have added a new required parameter of SoapUI MockAsWar constructor parsing the WsdlProject object. I have not tested it because is not needed for my project.